### PR TITLE
add `--bell` feature to RichReporter

### DIFF
--- a/tests/plugins/director/rich/reporter/_utils.py
+++ b/tests/plugins/director/rich/reporter/_utils.py
@@ -58,7 +58,8 @@ async def fire_arg_parsed_event(dispatcher: Dispatcher, *,
                                 show_scenario_spinner: bool = RichReporter_.show_scenario_spinner,
                                 hide_namespaces: bool = RichReporter_.hide_namespaces,
                                 tb_show_internal_calls: bool = RichReporter_.tb_show_internal_calls,  # noqa: E501
-                                tb_show_locals: bool = RichReporter_.tb_show_locals) -> None:
+                                tb_show_locals: bool = RichReporter_.tb_show_locals,
+                                ring_bell: bool = RichReporter_.ring_bell) -> None:
     await dispatcher.fire(ConfigLoadedEvent(Path(), Config))
 
     arg_parse_event = ArgParseEvent(ArgumentParser())
@@ -71,7 +72,8 @@ async def fire_arg_parsed_event(dispatcher: Dispatcher, *,
                           show_scenario_spinner=show_scenario_spinner,
                           hide_namespaces=hide_namespaces,
                           tb_show_internal_calls=tb_show_internal_calls,
-                          tb_show_locals=tb_show_locals)
+                          tb_show_locals=tb_show_locals,
+                          ring_bell=ring_bell)
     arg_parsed_event = ArgParsedEvent(namespace)
     await dispatcher.fire(arg_parsed_event)
 

--- a/tests/plugins/director/rich/reporter/test_rich_reporter.py
+++ b/tests/plugins/director/rich/reporter/test_rich_reporter.py
@@ -275,3 +275,18 @@ async def test_cleanup_interrupted(*, dispatcher: Dispatcher, printer_: Mock):
                                     elapsed=report.elapsed,
                                     is_interrupted=True)
         ]
+
+
+@pytest.mark.usefixtures(rich_reporter.__name__)
+async def test_cleanup_ring_bell(*, dispatcher: Dispatcher, printer_: Mock):
+    with given:
+        await fire_arg_parsed_event(dispatcher, ring_bell=True)
+
+        report = Report()
+        event = CleanupEvent(report)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        assert printer_.console.mock_calls == [call.bell()]

--- a/vedro/plugins/director/rich/_rich_reporter.py
+++ b/vedro/plugins/director/rich/_rich_reporter.py
@@ -42,6 +42,7 @@ class RichReporterPlugin(Reporter):
         self._show_scenario_spinner = config.show_scenario_spinner
         self._show_interrupted_traceback = config.show_interrupted_traceback
         self._v2_verbosity = config.v2_verbosity
+        self._ring_bell = config.ring_bell
         self._namespace: Union[str, None] = None
 
     def subscribe(self, dispatcher: Dispatcher) -> None:
@@ -101,6 +102,11 @@ class RichReporterPlugin(Reporter):
                            action="store_true",
                            default=self._tb_show_locals,
                            help="Show local variables in the traceback output")
+        group.add_argument("-B", "--bell",
+                           action="store_true",
+                           default=self._ring_bell,
+                           dest="ring_bell",
+                           help="Trigger a 'bell' sound at the end of scenario execution")
 
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
         self._verbosity = event.args.verbose
@@ -113,6 +119,7 @@ class RichReporterPlugin(Reporter):
         self._hide_namespaces = event.args.hide_namespaces
         self._tb_show_internal_calls = event.args.tb_show_internal_calls
         self._tb_show_locals = event.args.tb_show_locals
+        self._ring_bell = event.args.ring_bell
 
         if self._tb_max_frames < 4:
             raise ValueError("RichReporter: `tb_max_frames` must be >= 4")
@@ -290,6 +297,9 @@ class RichReporterPlugin(Reporter):
                                          elapsed=event.report.elapsed,
                                          is_interrupted=is_interrupted)
 
+        if self._ring_bell:
+            self._printer.console.bell()
+
 
 class RichReporter(PluginConfig):
     plugin = RichReporterPlugin
@@ -348,3 +358,7 @@ class RichReporter(PluginConfig):
 
     # Enable new verbose levels
     v2_verbosity: bool = True
+
+    # Trigger a 'bell' sound at the end of scenario execution
+    # (if supported by the terminal)
+    ring_bell: bool = False


### PR DESCRIPTION
Hello.

I've introduced a `--bell` argument in the RichReporter plugin. This feature, when enabled using `-B` or `--bell`, emits a bell sound at the end of scenario execution. It's designed to provide immediate auditory feedback, enhancing usability during test runs. This optional feature is a small yet useful addition, maintaining Vedro's focus on a user-friendly testing experience.