### PR TITLE
Add caseless keyword matching to Tagger plugin

### DIFF
--- a/tests/plugins/tagger/test_logic_tag_matcher.py
+++ b/tests/plugins/tagger/test_logic_tag_matcher.py
@@ -47,6 +47,9 @@ def test_invalid_expr():
     "and",
     "or",
     "not",
+    "AND",
+    "OR",
+    "NOT",
 ])
 def test_invalid_tag(expr: str):
     with given:

--- a/tests/plugins/tagger/test_tagger_plugin.py
+++ b/tests/plugins/tagger/test_tagger_plugin.py
@@ -44,6 +44,16 @@ async def test_nonexisting_tag(*, dispatcher: Dispatcher):
 
 
 @pytest.mark.usefixtures(tagger.__name__)
+async def test_empty_tags_error(*, dispatcher: Dispatcher):
+    with when, raises(Exception) as exc:
+        await fire_arg_parsed_event(dispatcher, tags="")
+
+    with then:
+        assert exc.type is ValueError
+        assert str(exc.value) == "Tags cannot be an empty string. Please specify valid tags."
+
+
+@pytest.mark.usefixtures(tagger.__name__)
 async def test_tag(*, dispatcher: Dispatcher):
     with given:
         await fire_arg_parsed_event(dispatcher, tags="SMOKE")

--- a/vedro/plugins/tagger/_tag_matcher.py
+++ b/vedro/plugins/tagger/_tag_matcher.py
@@ -5,13 +5,39 @@ __all__ = ("TagMatcher",)
 
 
 class TagMatcher(ABC):
+    """
+    Defines an abstract base class for matching tags against a logical expression.
+
+    Subclasses must implement the `match` method to evaluate if a set of tags satisfies
+    a given expression, and the `validate` method to check if individual tags are valid.
+    """
+
     def __init__(self, expr: str) -> None:
+        """
+        Initialize the TagMatcher with a logical expression string.
+
+        :param expr: The logical expression string to be used for tag matching.
+        """
         self._expr = expr
 
     @abstractmethod
     def match(self, tags: Set[str]) -> bool:
+        """
+        Evaluate whether the given set of tags matches the logical expression.
+
+        :param tags: A set of strings representing the tags to evaluate.
+        :return: True if the tags match the expression, False otherwise.
+        """
         pass
 
     @abstractmethod
     def validate(self, tag: str) -> bool:
+        """
+        Validate whether a given tag conforms to expected rules or syntax.
+
+        :param tag: The tag to validate.
+        :return: True if the tag is valid, raises an exception otherwise.
+        :raises TypeError: If the tag is not a string.
+        :raises ValueError: If the tag does not conform to the expected format.
+        """
         pass

--- a/vedro/plugins/tagger/_tagger.py
+++ b/vedro/plugins/tagger/_tagger.py
@@ -30,6 +30,8 @@ class TaggerPlugin(Plugin):
 
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
         self._tags_expr = event.args.tags
+        if isinstance(self._tags_expr, str) and self._tags_expr.strip() == "":
+            raise ValueError("Tags cannot be an empty string. Please specify valid tags.")
 
     def _get_tags(self, scenario: VirtualScenario, validate: Callable[[str], bool]) -> Any:
         orig_tags = getattr(scenario._orig_scenario, "tags", ())

--- a/vedro/plugins/tagger/_tagger.py
+++ b/vedro/plugins/tagger/_tagger.py
@@ -24,8 +24,9 @@ class TaggerPlugin(Plugin):
             .listen(StartupEvent, self.on_startup)
 
     def on_arg_parse(self, event: ArgParseEvent) -> None:
-        event.arg_parser.add_argument("-t", "--tags",
-                                      help="Specify tags to selectively run scenarios")
+        help_message = ("Specify tags to selectively run scenarios. "
+                        "More info: vedro.io/docs/features/tags")
+        event.arg_parser.add_argument("-t", "--tags", help=help_message)
 
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
         self._tags_expr = event.args.tags

--- a/vedro/plugins/tagger/_tagger.py
+++ b/vedro/plugins/tagger/_tagger.py
@@ -11,29 +11,70 @@ __all__ = ("Tagger", "TaggerPlugin",)
 
 
 class TaggerPlugin(Plugin):
+    """
+    Implements a plugin that allows selective scenario execution based on tags.
+
+    The plugin subscribes to various events during the lifecycle of a test run, parses
+    user-specified tag expressions, and filters scenarios accordingly. The logical
+    expressions are evaluated using a `TagMatcher` instance, which determines if
+    a scenario should be executed based on its associated tags.
+    """
+
     def __init__(self, config: Type["Tagger"], *,
                  tag_matcher_factory: Callable[[str], TagMatcher] = LogicTagMatcher) -> None:
+        """
+        Initialize the TaggerPlugin with a configuration and a tag matcher factory.
+
+        :param config: The configuration class for the TaggerPlugin.
+        :param tag_matcher_factory: A callable that creates a TagMatcher instance given a tag
+                                    expression. Defaults to `LogicTagMatcher`.
+        """
         super().__init__(config)
         self._matcher_factory = tag_matcher_factory
         self._matcher: Union[TagMatcher, None] = None
         self._tags_expr: Union[str, None] = None
 
     def subscribe(self, dispatcher: Dispatcher) -> None:
+        """
+        Subscribe the plugin to relevant events in the dispatcher's event lifecycle.
+
+        :param dispatcher: The event dispatcher to which the plugin subscribes.
+        """
         dispatcher.listen(ArgParseEvent, self.on_arg_parse) \
             .listen(ArgParsedEvent, self.on_arg_parsed) \
             .listen(StartupEvent, self.on_startup)
 
     def on_arg_parse(self, event: ArgParseEvent) -> None:
+        """
+        Handle the `ArgParseEvent` by adding the tag argument to the argument parser.
+
+        :param event: The event containing the argument parser.
+        """
         help_message = ("Specify tags to selectively run scenarios. "
                         "More info: vedro.io/docs/features/tags")
         event.arg_parser.add_argument("-t", "--tags", help=help_message)
 
     def on_arg_parsed(self, event: ArgParsedEvent) -> None:
+        """
+        Handle the `ArgParsedEvent` by storing the parsed tags expression.
+
+        :param event: The event containing parsed arguments.
+        :raises ValueError: If the provided tags argument is an empty string.
+        """
         self._tags_expr = event.args.tags
         if isinstance(self._tags_expr, str) and self._tags_expr.strip() == "":
             raise ValueError("Tags cannot be an empty string. Please specify valid tags.")
 
     def _get_tags(self, scenario: VirtualScenario, validate: Callable[[str], bool]) -> Any:
+        """
+        Retrieve and validate the tags associated with a scenario.
+
+        :param scenario: The scenario from which to extract tags.
+        :param validate: A callable to validate each tag.
+        :return: A list of validated tags.
+        :raises TypeError: If the scenario's tags are not a list, tuple, or set.
+        :raises ValueError: If any tag is not valid.
+        """
         orig_tags = getattr(scenario._orig_scenario, "tags", ())
         if not isinstance(orig_tags, (list, tuple, set)):
             raise TypeError(f"Scenario '{scenario.unique_id}' tags must be a list, tuple or set, "
@@ -51,6 +92,11 @@ class TaggerPlugin(Plugin):
         return tags
 
     async def on_startup(self, event: StartupEvent) -> None:
+        """
+        Handle the `StartupEvent` by filtering scenarios based on the provided tags expression.
+
+        :param event: The startup event containing the scenario scheduler.
+        """
         self._matcher = self._matcher_factory(str(self._tags_expr))
 
         async for scenario in event.scheduler:
@@ -60,5 +106,9 @@ class TaggerPlugin(Plugin):
 
 
 class Tagger(PluginConfig):
+    """
+    Configuration class for the TaggerPlugin.
+    """
+
     plugin = TaggerPlugin
     description = "Allows scenarios to be selectively run based on user-defined tags"

--- a/vedro/plugins/tagger/logic_tag_matcher/_logic_ops.py
+++ b/vedro/plugins/tagger/logic_tag_matcher/_logic_ops.py
@@ -5,60 +5,178 @@ __all__ = ("And", "Or", "Not", "Operand", "Operator", "Expr",)
 
 
 class Expr(ABC):
+    """
+    Represents an abstract base class for all expressions.
+
+    This class provides an interface for evaluating logical expressions
+    on a set of tags. It must be subclassed by specific expression types
+    like operands and operators.
+    """
+
     @abstractmethod
     def __call__(self, tags: Set[str]) -> bool:
+        """
+        Evaluate the expression based on the provided tags.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: A boolean result of the evaluation.
+        """
         pass
 
     @abstractmethod
     def __repr__(self) -> str:
+        """
+        Return a string representation of the expression.
+
+        :return: A string representation of the expression.
+        """
         pass
 
 
 class Operator(Expr, ABC):
+    """
+    Serves as an abstract base class for logical operators.
+
+    Logical operators (e.g., And, Or, Not) combine or modify operands and are
+    used to construct complex logical expressions.
+    """
     pass
 
 
 class Operand(Expr):
+    """
+    Represents an operand in a logical expression.
+
+    An operand is a tag that is checked for membership in a given set of tags.
+    """
+
     def __init__(self, tag: str) -> None:
+        """
+        Initialize the Operand with a specific tag.
+
+        :param tag: The tag to be checked in a set of tags.
+        """
         self._tag = tag
 
     def __call__(self, tags: Set[str]) -> bool:
+        """
+        Check if the operand's tag is present in the provided set of tags.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: True if the tag is in the set, False otherwise.
+        """
         return self._tag in tags
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the operand.
+
+        :return: A string in the form 'Tag(tag)'.
+        """
         return f"Tag({self._tag})"
 
 
 class And(Operator):
+    """
+    Represents a logical AND operation between two operands.
+
+    The result of the AND operation is True if both operands evaluate to True
+    when applied to a set of tags.
+    """
+
     def __init__(self, left: Operand, right: Operand) -> None:
+        """
+        Initialize the And operator with two operands.
+
+        :param left: The left operand in the AND operation.
+        :param right: The right operand in the AND operation.
+        """
         self._left = left
         self._right = right
 
     def __call__(self, tags: Set[str]) -> bool:
+        """
+        Evaluate the AND operation on the provided set of tags.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: True if both the left and right operands evaluate to True, False otherwise.
+        """
         return self._left(tags) and self._right(tags)
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the AND operation.
+
+        :return: A string in the form 'And(left_operand, right_operand)'.
+        """
         return f"And({self._left}, {self._right})"
 
 
 class Or(Operator):
+    """
+    Represents a logical OR operation between two operands.
+
+    The result of the OR operation is True if either operand evaluates to True
+    when applied to a set of tags.
+    """
+
     def __init__(self, left: Operand, right: Operand) -> None:
+        """
+        Initialize the Or operator with two operands.
+
+        :param left: The left operand in the OR operation.
+        :param right: The right operand in the OR operation.
+        """
         self._left = left
         self._right = right
 
     def __call__(self, tags: Set[str]) -> bool:
+        """
+        Evaluate the OR operation on the provided set of tags.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: True if either the left or right operand evaluates to True, False otherwise.
+        """
         return self._left(tags) or self._right(tags)
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the OR operation.
+
+        :return: A string in the form 'Or(left_operand, right_operand)'.
+        """
         return f"Or({self._left}, {self._right})"
 
 
 class Not(Operator):
+    """
+    Represents a logical NOT operation on a single operand.
+
+    The result of the NOT operation is True if the operand evaluates to False
+    when applied to a set of tags, and False if the operand evaluates to True.
+    """
+
     def __init__(self, operand: Operand) -> None:
+        """
+        Initialize the Not operator with a single operand.
+
+        :param operand: The operand to be negated in the NOT operation.
+        """
         self._operand = operand
 
     def __call__(self, tags: Set[str]) -> bool:
+        """
+        Evaluate the NOT operation on the provided set of tags.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: True if the operand evaluates to False, False if the operand evaluates to True.
+        """
         return not self._operand(tags)
 
     def __repr__(self) -> str:
+        """
+        Return a string representation of the NOT operation.
+
+        :return: A string in the form 'Not(operand)'.
+        """
         return f"Not({self._operand})"

--- a/vedro/plugins/tagger/logic_tag_matcher/_logic_tag_matcher.py
+++ b/vedro/plugins/tagger/logic_tag_matcher/_logic_tag_matcher.py
@@ -14,9 +14,25 @@ __all__ = ("LogicTagMatcher",)
 
 
 class LogicTagMatcher(TagMatcher):
+    """
+    Implements a tag matcher that evaluates logical expressions using the `And`, `Or`,
+    and `Not` operators.
+
+    This class parses a logical expression string consisting of operands (tags) and logical
+    operators, and evaluates whether a given set of tags satisfies the parsed expression.
+    Tags are checked for membership in the set, and logical operators are applied according to
+    standard boolean logic.
+    """
+
     tag_pattern = r'(?!and$|or$|not$)[A-Za-z_][A-Za-z0-9_]*'
 
     def __init__(self, expr: str) -> None:
+        """
+        Initialize the LogicTagMatcher with a logical expression string.
+
+        :param expr: The logical expression string to parse and evaluate.
+                     The expression can contain tag names, 'and', 'or', 'not' logical operators.
+        """
         super().__init__(expr)
         operand = Regex(self.tag_pattern, re.IGNORECASE).setParseAction(self._create_tag)
         self._parser = infixNotation(operand, [
@@ -27,11 +43,26 @@ class LogicTagMatcher(TagMatcher):
         self._grammar: Union[Expr, None] = None
 
     def match(self, tags: Set[str]) -> bool:
+        """
+        Match the provided set of tags against the parsed logical expression.
+
+        :param tags: A set of strings representing tags to evaluate.
+        :return: True if the set of tags satisfies the logical expression, False otherwise.
+        """
         if self._grammar is None:
             self._grammar = self._parse(self._parser, self._expr)
         return self._grammar(tags)
 
     def validate(self, tag: str) -> bool:
+        """
+        Validate whether a tag conforms to the allowed tag pattern.
+
+        :param tag: The tag to validate.
+        :return: True if the tag is valid, raises an exception otherwise.
+        :raises TypeError: If the tag is not a string.
+        :raises ValueError: If the tag does not match the required pattern, or if it is a
+                            reserved keyword.
+        """
         if not isinstance(tag, str):
             raise TypeError(f"Tag must be a str, got {type(tag)}")
 
@@ -44,24 +75,66 @@ class LogicTagMatcher(TagMatcher):
         return True
 
     def _create_tag(self, orig: str, location: int, tokens: ParseResults) -> Expr:
+        """
+        Create an Operand expression from a parsed tag.
+
+        :param orig: The original input string (unused).
+        :param location: The location of the match in the string (unused).
+        :param tokens: The parsed tokens, where the first token is the tag.
+        :return: An Operand instance representing the parsed tag.
+        """
         tag = tokens[0]
         return Operand(tag)
 
     def _create_not(self, orig: str, location: int, tokens: ParseResults) -> Expr:
+        """
+        Create a Not operator expression from parsed tokens.
+
+        :param orig: The original input string (unused).
+        :param location: The location of the match in the string (unused).
+        :param tokens: The parsed tokens, where the operand to negate is in the tokens.
+        :return: A Not instance representing the negation of the operand.
+        """
         operand = tokens[0][-1]
         return Not(operand)
 
     def _create_and(self, orig: str, location: int, tokens: ParseResults) -> Expr:
+        """
+        Create an And operator expression from parsed tokens.
+
+        :param orig: The original input string (unused).
+        :param location: The location of the match in the string (unused).
+        :param tokens: The parsed tokens, where the first token is the left operand and
+                       the last token is the right operand.
+        :return: An And instance representing the logical AND of the two operands.
+        """
         left = tokens[0][0]
         right = tokens[0][-1]
         return And(left, right)
 
     def _create_or(self, orig: str, location: int, tokens: ParseResults) -> Expr:
+        """
+        Create an Or operator expression from parsed tokens.
+
+        :param orig: The original input string (unused).
+        :param location: The location of the match in the string (unused).
+        :param tokens: The parsed tokens, where the first token is the left operand and
+                       the last token is the right operand.
+        :return: An Or instance representing the logical OR of the two operands.
+        """
         left = tokens[0][0]
         right = tokens[0][-1]
         return Or(left, right)
 
     def _parse(self, grammar: Parser, expr: str) -> Expr:
+        """
+        Parse the provided logical expression using the grammar.
+
+        :param grammar: The parser grammar to use for parsing the expression.
+        :param expr: The logical expression string to parse.
+        :return: An Expr instance representing the parsed logical expression.
+        :raises ValueError: If the expression is invalid or cannot be parsed.
+        """
         try:
             results = grammar.parse_string(expr, parse_all=True)
         except ParseException as e:


### PR DESCRIPTION
This PR enhances the `Tagger` plugin by adding support for caseless keyword matching ("and," "or," and "not"). This allows users to specify tags in a case-insensitive manner, improving usability and flexibility.