### PR TITLE
Handle OSError for empty files in `inspect.getsource()`

### DIFF
--- a/tests/plugins/assert_rewriter/test_assert_rewriter_loader.py
+++ b/tests/plugins/assert_rewriter/test_assert_rewriter_loader.py
@@ -64,3 +64,17 @@ async def test_load_assertion_failure_with_message(tmp_scn_dir: Path):
         assert assert_.get_right(exc.value) == 2
         assert assert_.get_operator(exc.value) == CompareOperator.EQUAL
         assert assert_.get_message(exc.value) == "assertion failed"
+
+
+async def test_load_empty_scenario_file(tmp_scn_dir: Path):
+    with given:
+        path = tmp_scn_dir / "scenario.py"
+        path.write_text("")
+
+        loader = AssertRewriterLoader()
+
+    with when:
+        module = await loader.load(path)
+
+    with then:
+        assert module is not None


### PR DESCRIPTION
When attempting to load a module using `inspect.getsource()` with empty Python files, an `OSError` is raised, stating "could not get source code." This issue occurs due to the handling of files with no lines, as described in [Python issue #27578](https://bugs.python.org/issue27578).

This bug affects the `AssertRewriterLoader` when inspecting source code for assertion rewriting. The fix adds a fallback mechanism to manually read the file when the error occurs.