### PR TITLE
Add `--no-tmp-cleanup` CLI option to TempKeeper plugin

### DIFF
--- a/tests/plugins/temp_keeper/_utils.py
+++ b/tests/plugins/temp_keeper/_utils.py
@@ -36,9 +36,11 @@ async def fire_config_loaded_event(dispatcher: Dispatcher, project_directory: Pa
     await dispatcher.fire(config_loaded_event)
 
 
-async def fire_arg_parsed_event(dispatcher: Dispatcher, *, tmp_dir: Path):
+async def fire_arg_parsed_event(dispatcher: Dispatcher, *,
+                                tmp_dir: Path = TempKeeper.tmp_dir,
+                                no_tmp_cleanup: bool = not TempKeeper.cleanup_tmp):
     arg_parse_event = ArgParseEvent(ArgumentParser())
     await dispatcher.fire(arg_parse_event)
 
-    arg_parsed_event = ArgParsedEvent(Namespace(tmp_dir=tmp_dir))
+    arg_parsed_event = ArgParsedEvent(Namespace(tmp_dir=tmp_dir, no_tmp_cleanup=no_tmp_cleanup))
     await dispatcher.fire(arg_parsed_event)

--- a/tests/plugins/temp_keeper/_utils.py
+++ b/tests/plugins/temp_keeper/_utils.py
@@ -1,10 +1,10 @@
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 import pytest
 
 from vedro.core import Config, Dispatcher
-from vedro.events import ArgParsedEvent, ConfigLoadedEvent
+from vedro.events import ArgParsedEvent, ArgParseEvent, ConfigLoadedEvent
 from vedro.plugins.temp_keeper import TempFileManager, TempKeeper, TempKeeperPlugin
 
 __all__ = ("dispatcher", "temp_file_manager", "temp_keeper", "fire_arg_parsed_event",
@@ -36,6 +36,9 @@ async def fire_config_loaded_event(dispatcher: Dispatcher, project_directory: Pa
     await dispatcher.fire(config_loaded_event)
 
 
-async def fire_arg_parsed_event(dispatcher: Dispatcher):
-    arg_parsed_event = ArgParsedEvent(Namespace())
+async def fire_arg_parsed_event(dispatcher: Dispatcher, *, tmp_dir: Path):
+    arg_parse_event = ArgParseEvent(ArgumentParser())
+    await dispatcher.fire(arg_parse_event)
+
+    arg_parsed_event = ArgParsedEvent(Namespace(tmp_dir=tmp_dir))
     await dispatcher.fire(arg_parsed_event)

--- a/vedro/core/config_loader/_config_type.py
+++ b/vedro/core/config_loader/_config_type.py
@@ -98,7 +98,7 @@ This is a re-export of `cabina.env`, used to declare configuration properties
 whose values are populated from environment variables.
 """
 
-lazy_env = cabina.lazy_env
+lazy_env = getattr(cabina, "lazy_env", env)  # backward compatibility for older versions
 """
 Decorator to define lazily evaluated environment-variable-based properties.
 

--- a/vedro/plugins/artifacted/_artifacted.py
+++ b/vedro/plugins/artifacted/_artifacted.py
@@ -103,7 +103,7 @@ class ArtifactedPlugin(Plugin):
         self._scenario_artifacts = scenario_artifacts
         self._step_artifacts = step_artifacts
         self._save_artifacts = config.save_artifacts
-        self._artifacts_dir = config.artifacts_dir
+        self._artifacts_dir = Path(config.artifacts_dir)
         self._add_artifact_details = config.add_artifact_details
         self._cleanup_artifacts_dir = config.cleanup_artifacts_dir
         self._global_config: Union[ConfigType, None] = None


### PR DESCRIPTION
- Add `cleanup_tmp` option to TempKeeper plugin config (default: `True`)
- Add `--no-tmp-cleanup` CLI flag to control cleanup behavior
- CLI flag overrides config value and defaults to `not cleanup_tmp`
