### PR TITLE
Improve skipper decorators with enhanced type hints and error messages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ show_missing = true
 exclude_lines = 
 	pragma: no cover
 	@abstractmethod
+    @overload
 
 [tool:pytest]
 testpaths = tests/

--- a/tests/plugins/functioner/test_scenario_provider.py
+++ b/tests/plugins/functioner/test_scenario_provider.py
@@ -38,8 +38,8 @@ async def test_func_scenario_detected(fn_def: str, is_coro: bool, *,
         # scenario
         scenario = scenarios[0]
         assert scenario.subject == "create user"
-        assert scenario.name == "Scenario_create_user"
-        assert scenario.unique_id == "scenarios/scenario.py::Scenario_create_user"
+        assert scenario.name == "create_user"
+        assert scenario.unique_id == "scenarios/scenario.py::create_user"
         assert scenario.template_index is None
         assert scenario.template_total is None
 
@@ -73,8 +73,8 @@ async def test_parametrized_func_scenarios(provider: ScenarioProvider,
 
         for idx, scenario in enumerate(scenarios, start=1):
             assert scenario.subject == "create user"
-            assert scenario.name == "Scenario_create_user"
-            assert scenario.unique_id == f"scenarios/scenario.py::Scenario_create_user#{idx}"
+            assert scenario.name == "create_user"
+            assert scenario.unique_id == f"scenarios/scenario.py::create_user#{idx}"
             assert scenario.template_index == idx
             assert scenario.template_total == 2
 

--- a/tests/plugins/skipper/test_only_decorator.py
+++ b/tests/plugins/skipper/test_only_decorator.py
@@ -37,8 +37,7 @@ def test_only_not_subclass():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == ("Decorator @only can be used only with """
-                                  "'vedro.Scenario' subclasses")
+        assert str(exc.value).startswith("Decorator @only can be used only with Vedro scenarios")
 
 
 def test_only_called_not_subclass():
@@ -49,8 +48,7 @@ def test_only_called_not_subclass():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == ("Decorator @only can be used only with """
-                                  "'vedro.Scenario' subclasses")
+        assert str(exc.value).startswith("Decorator @only can be used only with Vedro scenarios")
 
 
 def test_only_called_with_incorrect_arg():
@@ -61,4 +59,4 @@ def test_only_called_with_incorrect_arg():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == "Usage: @only"
+        assert str(exc.value).startswith("Decorator @only can be used only with Vedro scenarios")

--- a/tests/plugins/skipper/test_skip_decorator.py
+++ b/tests/plugins/skipper/test_skip_decorator.py
@@ -55,8 +55,18 @@ def test_skip_not_subclass():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == ("Decorator @skip can be used only with """
-                                  "'vedro.Scenario' subclasses")
+        assert str(exc.value).startswith("Decorator @skip can be used only with Vedro scenarios:")
+
+
+def test_skip_not_subclass_with_reason():
+    with when, raises(BaseException) as exc:
+        @skip("<reason>")
+        class _Scenario:
+            pass
+
+    with then:
+        assert exc.type is TypeError
+        assert str(exc.value).startswith("Decorator @skip can be used only with Vedro scenarios:")
 
 
 def test_skip_called_not_subclass():
@@ -67,8 +77,7 @@ def test_skip_called_not_subclass():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == ("Decorator @skip can be used only with """
-                                  "'vedro.Scenario' subclasses")
+        assert str(exc.value).startswith("Decorator @skip can be used only with Vedro scenarios:")
 
 
 def test_skip_called_with_incorrect_arg():
@@ -79,4 +88,4 @@ def test_skip_called_with_incorrect_arg():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == 'Usage: @skip or @skip("reason")'
+        assert str(exc.value).startswith("Decorator @skip can be used only with Vedro scenarios:")

--- a/tests/plugins/skipper/test_skip_if_decorator.py
+++ b/tests/plugins/skipper/test_skip_if_decorator.py
@@ -55,8 +55,24 @@ def test_skip_if_not_subclass():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == ("Decorator @skip_if can be used only with "
-                                  "'vedro.Scenario' subclasses")
+        assert str(exc.value).startswith(
+            "Decorator @skip_if must be used as @skip_if(<condition>, 'reason?') "
+            "and only with Vedro scenarios:"
+        )
+
+
+def test_skip_if_not_subclass_with_reason():
+    with when, raises(BaseException) as exc:
+        @skip_if(lambda: True, "<reason>")
+        class _Scenario:
+            pass
+
+    with then:
+        assert exc.type is TypeError
+        assert str(exc.value).startswith(
+            "Decorator @skip_if must be used as @skip_if(<condition>, 'reason?') "
+            "and only with Vedro scenarios:"
+        )
 
 
 def test_skip_if():
@@ -67,7 +83,10 @@ def test_skip_if():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == 'Usage: @skip_if(<condition>, "reason?")'
+        assert str(exc.value).startswith(
+            "Decorator @skip_if must be used as @skip_if(<condition>, 'reason?') "
+            "and only with Vedro scenarios:"
+        )
 
 
 def test_skip_if_not_callable():
@@ -78,4 +97,7 @@ def test_skip_if_not_callable():
 
     with then:
         assert exc.type is TypeError
-        assert str(exc.value) == 'Usage: @skip_if(<condition>, "reason?")'
+        assert str(exc.value).startswith(
+            "Decorator @skip_if must be used as @skip_if(<condition>, 'reason?') "
+            "and only with Vedro scenarios:"
+        )

--- a/vedro/plugins/functioner/_func_based_scenario_provider.py
+++ b/vedro/plugins/functioner/_func_based_scenario_provider.py
@@ -67,7 +67,7 @@ class FuncBasedScenarioProvider(ScenarioProvider):
 
         scenarios = []
         for idx, _ in enumerate(descriptor.params, start=1):
-            scn_name = f"Scenario_{descriptor.name}_{idx}_VedroScenario"
+            scn_name = f"{self._create_scenario_name(descriptor)}_{idx}_VedroScenario"
             scenarios.append(
                 # This is a temporary and dirty workaround; to be revisited after the v2 release
                 # Logic adapted from the `_Meta` class in vedro/_scenario.py
@@ -130,7 +130,7 @@ class FuncBasedScenarioProvider(ScenarioProvider):
         :param descriptor: The scenario descriptor to derive the name from.
         :return: A string representing the scenario class name.
         """
-        return f"Scenario_{descriptor.name}"
+        return f"{descriptor.name}"
 
     def _create_subject(self, descriptor: ScenarioDescriptor) -> str:
         """

--- a/vedro/plugins/skipper/_only.py
+++ b/vedro/plugins/skipper/_only.py
@@ -14,17 +14,60 @@ Decorator = Callable[[Type[T]], Type[T]]
 
 
 @overload
-def only(scenario: Type[T]) -> Type[T]:  # @only
+def only(scenario: Type[T]) -> Type[T]:
+    """
+    Enable usage as `@only` to designate a scenario for exclusive execution.
+
+    :param scenario: The scenario class to be designated as the only one to run.
+    :return: The same scenario class, flagged for exclusive execution.
+    """
     pass
 
 
 @overload
-def only() -> Decorator[T]:  # @only()
+def only() -> Decorator[T]:
+    """
+    Enable usage as `@only()` to return a decorator.
+
+    :return: A decorator that designates a scenario for exclusive execution.
+    """
     pass
 
 
 def only(scenario: Union[Type[T], None] = None) -> Union[Type[T], Decorator[T]]:
+    """
+    Designate a Vedro scenario class to be the only one selected for execution.
+
+    Can be used with or without parentheses: `@only` or `@only()`.
+
+    Usage examples:
+
+    cls-based:
+        @only
+        class Scenario(vedro.Scenario):
+            ...
+
+    fn-based:
+        @scenario[only]()
+        def subject():
+            ...
+
+    :param scenario: Scenario class to decorate, or None if used as @only().
+    :return: Decorated scenario class or a decorator.
+    :raises TypeError: If used on a non-Scenario class.
+
+    For more details and examples, see:
+    https://vedro.io/docs/basics/selecting-and-ignoring
+    """
+
     def apply_only(scn: Type[T]) -> Type[T]:
+        """
+        Apply metadata indicating that this scenario should be the only one executed.
+
+        :param scn: Scenario class to designate for exclusive execution.
+        :return: The same scenario class with updated metadata.
+        :raises TypeError: If the argument is not a subclass of Scenario.
+        """
         if not isclass(scn) or not issubclass(scn, Scenario):
             raise TypeError(_format_only_usage_error())
 
@@ -33,14 +76,19 @@ def only(scenario: Union[Type[T], None] = None) -> Union[Type[T], Decorator[T]]:
 
         return cast(Type[T], scn)
 
-    # @only()
+    # When used with parentheses (e.g., @only()), return the decorator function
     if scenario is None:
         return apply_only
-    # @only
+    # When used without parentheses (e.g., @only), apply the decorator immediately
     return apply_only(scenario)
 
 
 def _format_only_usage_error() -> str:
+    """
+    Format an error message explaining correct usage of the @only decorator.
+
+    :return: A usage error message with examples for both class-based and function-based scenarios.
+    """
     return linesep.join([
         "Decorator @only can be used only with Vedro scenarios:",
         "",

--- a/vedro/plugins/skipper/_skip.py
+++ b/vedro/plugins/skipper/_skip.py
@@ -15,22 +15,72 @@ Decorator = Callable[[Type[T]], Type[T]]
 
 
 @overload
-def skip(scenario_or_reason: Type[T]) -> Type[T]:  # @skip
+def skip(scenario_or_reason: Type[T]) -> Type[T]:
+    """
+    Enable usage as `@skip` to exclude a scenario from execution.
+
+    :param scenario_or_reason: The scenario class to be excluded.
+    :return: The same scenario class, updated with skip metadata.
+    """
     pass
 
 
 @overload
-def skip() -> Decorator[T]:  # @skip()
+def skip() -> Decorator[T]:
+    """
+    Enable usage as `@skip()` to return a decorator.
+
+    :return: A decorator that excludes the decorated scenario from execution.
+    """
     pass
 
 
 @overload
-def skip(scenario_or_reason: str) -> Decorator[T]:  # @skip("reason")
+def skip(scenario_or_reason: str) -> Decorator[T]:
+    """
+    Enable usage as `@skip("reason")` to exclude a scenario with a reason.
+
+    :param scenario_or_reason: A string describing why the scenario is skipped.
+    :return: A decorator that excludes the scenario and stores the reason.
+    """
     pass
 
 
 def skip(scenario_or_reason: Union[Type[T], str, None] = None) -> Union[Type[T], Decorator[T]]:
+    """
+    Exclude a scenario class from execution, optionally providing a reason.
+
+    Can be used as `@skip`, `@skip()`, or `@skip("reason")`.
+
+    Usage examples:
+
+    cls-based:
+        @skip
+        class Scenario(vedro.Scenario):
+            ...
+
+    fn-based:
+        @scenario[skip]()
+        def subject():
+            ...
+
+    :param scenario_or_reason: Scenario class to decorate, a reason string,
+                               or None if used as @skip().
+    :return: Decorated scenario class or a decorator.
+    :raises TypeError: If applied to a non-Scenario class.
+
+    For more details and examples, see:
+    https://vedro.io/docs/features/skipping-scenarios
+    """
+
     def apply_skip(scn: Type[T]) -> Type[T]:
+        """
+        Apply skip metadata to a scenario class.
+
+        :param scn: Scenario class to exclude from execution.
+        :return: The same scenario class with skip metadata applied.
+        :raises TypeError: If the class is not a subclass of Scenario.
+        """
         if not isclass(scn) or not issubclass(scn, Scenario):
             raise TypeError(_format_skip_usage_error(scenario_or_reason))
 
@@ -43,14 +93,22 @@ def skip(scenario_or_reason: Union[Type[T], str, None] = None) -> Union[Type[T],
 
         return cast(Type[T], scn)
 
-    # @skip() or @skip("reason")
+    # When used with or without a reason string (e.g., @skip() or @skip("reason")),
+    # return the decorator function for later application.
     if (scenario_or_reason is None) or isinstance(scenario_or_reason, str):
         return apply_skip
-    # @skip
+    # When used without parentheses (e.g., @skip),
+    # apply the decorator immediately to the provided scenario class.
     return apply_skip(scenario_or_reason)
 
 
 def _format_skip_usage_error(maybe_reason: Any) -> str:
+    """
+    Generate a usage error message for incorrect usage of the @skip decorator.
+
+    :param maybe_reason: The provided argument to the decorator (could be a reason string).
+    :return: A formatted usage string with correct decorator examples.
+    """
     if isinstance(maybe_reason, str):
         decorator_repr = f"skip({maybe_reason!r})"
         fn_decorator_repr = f"scenario[{decorator_repr}]"

--- a/vedro/plugins/skipper/_skip.py
+++ b/vedro/plugins/skipper/_skip.py
@@ -1,5 +1,6 @@
 from inspect import isclass
-from typing import Callable, Type, TypeVar, overload
+from os import linesep
+from typing import Any, Callable, Type, TypeVar, Union, cast, overload
 
 from vedro._scenario import Scenario
 from vedro.core import set_scenario_meta
@@ -9,41 +10,64 @@ from ._skipper import SkipperPlugin
 __all__ = ("skip",)
 
 
-T = TypeVar("T", bound=Type[Scenario])
+T = TypeVar("T", bound=Scenario)
+Decorator = Callable[[Type[T]], Type[T]]
 
 
 @overload
-def skip(reason: T) -> T:  # pragma: no cover
+def skip(scenario_or_reason: Type[T]) -> Type[T]:  # @skip
     pass
 
 
 @overload
-def skip(reason: str) -> Callable[[T], T]:  # pragma: no cover
+def skip() -> Decorator[T]:  # @skip()
     pass
 
 
 @overload
-def skip(reason: None = None) -> Callable[[T], T]:  # pragma: no cover
+def skip(scenario_or_reason: str) -> Decorator[T]:  # @skip("reason")
     pass
 
 
-def skip(reason=None):  # type: ignore
-    def wrapped(scenario: T) -> T:
-        if not issubclass(scenario, Scenario):
-            raise TypeError("Decorator @skip can be used only with 'vedro.Scenario' subclasses")
+def skip(scenario_or_reason: Union[Type[T], str, None] = None) -> Union[Type[T], Decorator[T]]:
+    def apply_skip(scn: Type[T]) -> Type[T]:
+        if not isclass(scn) or not issubclass(scn, Scenario):
+            raise TypeError(_format_skip_usage_error(scenario_or_reason))
 
-        set_scenario_meta(scenario, key="skipped", value=True, plugin=SkipperPlugin,
+        set_scenario_meta(scn, key="skipped", value=True, plugin=SkipperPlugin,
                           fallback_key="__vedro__skipped__")
 
-        if isinstance(reason, str):
-            set_scenario_meta(scenario, key="skip_reason", value=reason, plugin=SkipperPlugin,
+        if isinstance(reason := scenario_or_reason, str):
+            set_scenario_meta(scn, key="skip_reason", value=reason, plugin=SkipperPlugin,
                               fallback_key="__vedro__skip_reason__")
 
-        return scenario
+        return cast(Type[T], scn)
 
-    if (reason is None) or isinstance(reason, str):
-        return wrapped
-    elif isclass(reason):
-        return wrapped(reason)
+    # @skip() or @skip("reason")
+    if (scenario_or_reason is None) or isinstance(scenario_or_reason, str):
+        return apply_skip
+    # @skip
+    return apply_skip(scenario_or_reason)
+
+
+def _format_skip_usage_error(maybe_reason: Any) -> str:
+    if isinstance(maybe_reason, str):
+        decorator_repr = f"skip({maybe_reason!r})"
+        fn_decorator_repr = f"scenario[{decorator_repr}]"
     else:
-        raise TypeError('Usage: @skip or @skip("reason")')
+        decorator_repr = "skip"
+        fn_decorator_repr = f"scenario[{decorator_repr}]()"
+
+    return linesep.join([
+        "Decorator @skip can be used only with Vedro scenarios:",
+        "",
+        "cls-based:",
+        f"    @{decorator_repr}",
+        "    class Scenario(vedro.Scenario):",
+        "        ...",
+        "",
+        "fn-based:",
+        f"    @{fn_decorator_repr}",
+        "    def subject():",
+        "        ...",
+    ])

--- a/vedro/plugins/skipper/_skip_if.py
+++ b/vedro/plugins/skipper/_skip_if.py
@@ -41,7 +41,7 @@ def skip_if(cond: Callable[[], bool], reason: Optional[str] = None) -> Decorator
     For more details and examples, see:
     https://vedro.io/docs/features/skipping-scenarios
     """
-    if not callable(cond):
+    if isinstance(cond, type) or not callable(cond):
         raise TypeError(_format_skip_if_usage_error(reason))
 
     def apply_skip_if(scenario: Type[T]) -> Type[T]:

--- a/vedro/plugins/skipper/_skip_if.py
+++ b/vedro/plugins/skipper/_skip_if.py
@@ -1,5 +1,6 @@
 from inspect import isclass
-from typing import Callable, Optional, Type, TypeVar
+from os import linesep
+from typing import Any, Callable, Optional, Type, TypeVar, cast
 
 from vedro._scenario import Scenario
 
@@ -8,18 +9,43 @@ from ._skip import skip
 __all__ = ("skip_if",)
 
 
-T = TypeVar("T", bound=Type[Scenario])
+T = TypeVar("T", bound=Scenario)
+Decorator = Callable[[Type[T]], Type[T]]
 
 
-def skip_if(cond: Callable[[], bool], reason: Optional[str] = None) -> Callable[[T], T]:
-    if isclass(cond) or not callable(cond):
-        raise TypeError('Usage: @skip_if(<condition>, "reason?")')
+def skip_if(cond: Callable[[], bool], reason: Optional[str] = None) -> Decorator[T]:
+    if not callable(cond):
+        raise TypeError(_format_skip_if_usage_error(reason))
 
-    def wrapped(scenario: T) -> T:
-        if not issubclass(scenario, Scenario):
-            raise TypeError("Decorator @skip_if can be used only with 'vedro.Scenario' subclasses")
+    def apply_skip_if(scenario: Type[T]) -> Type[T]:
+        if not isclass(scenario) or not issubclass(scenario, Scenario):
+            raise TypeError(_format_skip_if_usage_error(reason))
         if cond():
-            return skip(reason)(scenario)
-        return scenario
+            decorator = skip(reason) if reason is not None else skip()  # type: ignore
+            return decorator(scenario)
+        else:
+            return cast(Type[T], scenario)
 
-    return wrapped
+    return apply_skip_if
+
+
+def _format_skip_if_usage_error(maybe_reason: Any) -> str:
+    if maybe_reason is not None:
+        decorator_repr = f"skip_if(<cond>, {maybe_reason!r})"
+    else:
+        decorator_repr = "skip_if(<cond>)"
+
+    return linesep.join([
+        "Decorator @skip_if must be used as @skip_if(<condition>, 'reason?') "
+        "and only with Vedro scenarios:",
+        "",
+        "cls-based:",
+        f"    @{decorator_repr}",
+        "    class Scenario(vedro.Scenario):",
+        "        ...",
+        "",
+        "fn-based:",
+        f"    @scenario[{decorator_repr}]",
+        "    def subject():",
+        "        ...",
+    ])

--- a/vedro/plugins/skipper/_skip_if.py
+++ b/vedro/plugins/skipper/_skip_if.py
@@ -14,10 +14,44 @@ Decorator = Callable[[Type[T]], Type[T]]
 
 
 def skip_if(cond: Callable[[], bool], reason: Optional[str] = None) -> Decorator[T]:
+    """
+    Exclude a scenario from execution if a condition evaluates to True.
+
+    Can be used to dynamically skip scenarios. An optional reason can be provided to explain
+    why the scenario is being skipped, which helps improve test reporting and maintainability.
+
+    Usage examples:
+
+    cls-based:
+        @skip_if(lambda: True, "Not implemented")
+        class Scenario(vedro.Scenario):
+            ...
+
+    fn-based:
+        @scenario[skip_if(lambda: True, "Not implemented")]
+        def subject():
+            ...
+
+    :param cond: A callable that returns a boolean indicating whether to skip the scenario.
+    :param reason: Optional string describing the reason for skipping.
+    :return: A decorator that conditionally excludes the scenario from execution.
+    :raises TypeError: If `cond` is not callable or the decorator is applied to a non-Scenario
+                       class.
+
+    For more details and examples, see:
+    https://vedro.io/docs/features/skipping-scenarios
+    """
     if not callable(cond):
         raise TypeError(_format_skip_if_usage_error(reason))
 
     def apply_skip_if(scenario: Type[T]) -> Type[T]:
+        """
+        Apply the skip decorator if the condition evaluates to True.
+
+        :param scenario: Scenario class to be conditionally excluded.
+        :return: The same scenario class, optionally decorated with `skip`.
+        :raises TypeError: If applied to a non-Scenario class.
+        """
         if not isclass(scenario) or not issubclass(scenario, Scenario):
             raise TypeError(_format_skip_if_usage_error(reason))
         if cond():
@@ -30,6 +64,12 @@ def skip_if(cond: Callable[[], bool], reason: Optional[str] = None) -> Decorator
 
 
 def _format_skip_if_usage_error(maybe_reason: Any) -> str:
+    """
+    Generate a usage error message for incorrect use of the @skip_if decorator.
+
+    :param maybe_reason: The optional reason provided to the decorator.
+    :return: A formatted usage message with examples for correct usage.
+    """
     if maybe_reason is not None:
         decorator_repr = f"skip_if(<cond>, {maybe_reason!r})"
     else:


### PR DESCRIPTION
**Summary**
  - Enhanced type hints for `@only`, `@skip`, and `@skip_if` decorators to improve IDE support and type checking
  - Added detailed docstrings with usage examples for both class-based and function-based scenarios
  - Improved error messages with clear examples showing correct decorator usage