### PR TITLE
Add support for per-scenario seed configuration 

### DIFF
--- a/tests/plugins/seeder/_utils.py
+++ b/tests/plugins/seeder/_utils.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from random import random
-from typing import List, Optional
+from typing import Any, Callable, List, Optional
 
 import pytest
 
@@ -25,9 +25,14 @@ def seeder(dispatcher: Dispatcher) -> SeederPlugin:
     return seeder
 
 
-def make_vscenario(filename: str = "scenario.py", *, is_skipped: bool = False) -> VirtualScenario:
+def make_vscenario(filename: str = "scenario.py", *, is_skipped: bool = False,
+                   decorators: Optional[List[Callable[..., Any]]] = None) -> VirtualScenario:
     class _Scenario(Scenario):
         __file__ = Path(filename).absolute()
+
+    if decorators:
+        for decorator in decorators:
+            _Scenario = decorator(_Scenario)
 
     vscenario = VirtualScenario(_Scenario, steps=[])
     if is_skipped:

--- a/tests/plugins/seeder/test_seed_decorator.py
+++ b/tests/plugins/seeder/test_seed_decorator.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import pytest
+from baby_steps import given, then, when
+
+from vedro import Scenario
+from vedro.core import Dispatcher, get_scenario_meta
+from vedro.plugins.seeder import SeederPlugin, seed
+
+from ._utils import dispatcher, seeder
+
+__all__ = ("dispatcher", "seeder")  # fixtures
+
+
+CUSTOM_SEED = "custom-seed"
+
+
+async def test_seed_decorator_on_scenario_class(*, dispatcher: Dispatcher):
+    with given:
+        @seed(CUSTOM_SEED)
+        class CustomScenario(Scenario):
+            __file__ = Path("custom_scenario.py").absolute()
+
+    with when:
+        seed_value = get_scenario_meta(CustomScenario, key="seed", plugin=SeederPlugin)
+
+    with then:
+        assert seed_value == CUSTOM_SEED
+
+
+async def test_seed_decorator_type_error():
+    with when, pytest.raises(Exception) as exc_info:
+        @seed(CUSTOM_SEED)
+        class Scenario:
+            pass
+
+    with then:
+        assert exc_info.type is TypeError
+        assert "Decorator @seed can be used only with Vedro scenarios" in str(exc_info.value)
+        assert f"@seed({CUSTOM_SEED!r})" in str(exc_info.value)
+
+
+async def test_seed_decorator_on_function():
+    with given:
+        def fn():
+            pass
+
+    with when, pytest.raises(Exception) as exc_info:
+        seed(CUSTOM_SEED)(fn)
+
+    with then:
+        assert exc_info.type is TypeError
+        assert "Decorator @seed can be used only with Vedro scenarios" in str(exc_info.value)
+        assert f"@seed({CUSTOM_SEED!r})" in str(exc_info.value)

--- a/tests/plugins/seeder/test_seed_decorator.py
+++ b/tests/plugins/seeder/test_seed_decorator.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 from baby_steps import given, then, when
 
@@ -17,14 +15,16 @@ CUSTOM_SEED = "custom-seed"
 
 async def test_seed_decorator_on_scenario_class(*, dispatcher: Dispatcher):
     with given:
-        @seed(CUSTOM_SEED)
         class CustomScenario(Scenario):
-            __file__ = Path("custom_scenario.py").absolute()
+            pass
 
     with when:
-        seed_value = get_scenario_meta(CustomScenario, key="seed", plugin=SeederPlugin)
+        res = seed(CUSTOM_SEED)(CustomScenario)
 
     with then:
+        assert res == CustomScenario
+
+        seed_value = get_scenario_meta(CustomScenario, key="seed", plugin=SeederPlugin)
         assert seed_value == CUSTOM_SEED
 
 

--- a/tests/plugins/seeder/test_seeder_plugin.py
+++ b/tests/plugins/seeder/test_seeder_plugin.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 from baby_steps import given, then, when
 
+from vedro import seed
 from vedro.core import Dispatcher
 from vedro.core import MonotonicScenarioScheduler as Scheduler
 from vedro.core import Report, ScenarioResult
@@ -296,3 +297,22 @@ async def test_show_seeds(*, seeder: SeederPlugin, dispatcher: Dispatcher):
 
     with then:
         assert scenario_result.extra_details == ["seed: tbv2-kcvqg-bip6"]
+
+
+async def test_show_seeds_custom(*, seeder: SeederPlugin, dispatcher: Dispatcher):
+    with given:
+        await fire_arg_parsed_event(dispatcher, seed=SEED_INITIAL, show_seeds=True)
+
+        custom_seed = "em5i-xzqjv-dsey"
+        vscenario = make_vscenario("scenario-1.py", decorators=[seed(custom_seed)])
+        scheduler = Scheduler(scenarios=[vscenario])
+        await fire_startup_event(dispatcher, scheduler)
+
+        scenario_result = ScenarioResult(vscenario)
+        event = ScenarioRunEvent(scenario_result)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        assert scenario_result.extra_details == [f"seed: {custom_seed}"]

--- a/tests/plugins/seeder/test_seeder_plugin.py
+++ b/tests/plugins/seeder/test_seeder_plugin.py
@@ -26,14 +26,12 @@ __all__ = ("dispatcher", "seeder")  # fixtures
 
 SEED_INITIAL = "17b81c91"
 RAND_DISCOVERED = [
-    [18047, 912055, 192748],
-    [167430, 692919, 345483],
-    [429020, 174720, 28870],
+    [735076, 894332, 454659],
+    [821604, 234953, 290267],
 ]
 RAND_SCHEDULED = [
-    [18047, 912055, 192748],
-    [167430, 692919, 345483],
-    [429020, 174720, 28870],
+    [735076, 894332, 454659],
+    [821604, 234953, 290267],
 ]
 
 
@@ -53,7 +51,9 @@ async def test_no_seed(*, dispatcher: Dispatcher):
 
     with then:
         assert random_.mock_calls == [
-            call.set_seed(str(patched.return_value))
+            call.set_seed(
+                seeder._format_seed(str(patched.return_value))
+            )
         ]
 
 
@@ -295,4 +295,4 @@ async def test_show_seeds(*, seeder: SeederPlugin, dispatcher: Dispatcher):
         await dispatcher.fire(event)
 
     with then:
-        assert scenario_result.extra_details == ["seed: 75fc9f22..3b0238c4"]
+        assert scenario_result.extra_details == ["seed: tbv2-kcvqg-bip6"]

--- a/vedro/__init__.py
+++ b/vedro/__init__.py
@@ -21,6 +21,7 @@ from .plugins.artifacted import (
 from .plugins.deferrer import defer, defer_global
 from .plugins.ensurer import ensure
 from .plugins.functioner import given, scenario, then, when
+from .plugins.seeder import seed
 from .plugins.skipper import only, skip, skip_if
 from .plugins.temp_keeper import create_tmp_dir, create_tmp_file
 
@@ -28,7 +29,7 @@ __version__ = version
 __all__ = ("Scenario", "Interface", "run", "only", "skip", "skip_if", "params", "catched",
            "scenario", "given", "when", "then", "ensure", "context", "defer", "defer_global",
            "create_tmp_dir", "create_tmp_file", "attach_artifact", "attach_scenario_artifact",
-           "attach_step_artifact", "attach_global_artifact", "Config", "computed",
+           "attach_step_artifact", "attach_global_artifact", "seed", "Config", "computed",
            "MemoryArtifact", "FileArtifact", "Artifact",)
 
 

--- a/vedro/plugins/seeder/__init__.py
+++ b/vedro/plugins/seeder/__init__.py
@@ -1,5 +1,7 @@
 from ._random import RandomGenerator, StandardRandomGenerator
+from ._seed import seed
 from ._seeder import Seeder, SeederPlugin
 
 __all__ = ("Seeder", "SeederPlugin",
-           "RandomGenerator", "StandardRandomGenerator",)
+           "RandomGenerator", "StandardRandomGenerator",
+           "seed",)

--- a/vedro/plugins/seeder/_seed.py
+++ b/vedro/plugins/seeder/_seed.py
@@ -1,0 +1,90 @@
+from inspect import isclass
+from os import linesep
+from typing import Callable, Optional, Type, TypeVar, cast
+
+from vedro._scenario import Scenario
+from vedro.core import set_scenario_meta
+
+from ._seeder import SeederPlugin
+
+__all__ = ("seed",)
+
+
+T = TypeVar("T", bound=Scenario)
+
+
+def seed(seed_value: str, *,
+         use_fixed_seed: Optional[bool] = None) -> Callable[[Type[T]], Type[T]]:
+    """
+    Set a custom seed for a Vedro scenario, optionally specifying fixed seed behavior.
+
+    This decorator allows you to override the global seed settings for individual scenarios,
+    providing fine-grained control over the random behavior in specific test scenarios.
+
+    Usage examples:
+
+    cls-based:
+        @seed("custom-seed-123")
+        class Scenario(vedro.Scenario):
+            ...
+
+        @seed("custom-seed-456", use_fixed_seed=True)
+        class Scenario(vedro.Scenario):
+            ...
+
+    fn-based:
+        @scenario[seed("custom-seed-123")]()
+        def subject():
+            ...
+
+        @scenario[seed("custom-seed-456", use_fixed_seed=True)]()
+        def subject():
+            ...
+
+    :param seed_value: The seed value to use for this scenario.
+    :param use_fixed_seed: Whether to use the same seed for repeated runs of this scenario
+                          within the same test execution. If None, falls back to global setting.
+    :return: A decorator that applies the seed configuration to the scenario.
+    :raises TypeError: If used on a non-Scenario class.
+    """
+    def apply_seed(scn: Type[T]) -> Type[T]:
+        """
+        Apply seed metadata to the scenario for deterministic random behavior.
+
+        :param scn: Scenario class to apply the seed configuration to.
+        :return: The same scenario class with updated metadata.
+        :raises TypeError: If the argument is not a subclass of Scenario.
+        """
+        if not isclass(scn) or not issubclass(scn, Scenario):
+            raise TypeError(_format_seed_usage_error(seed_value))
+
+        set_scenario_meta(scn, key="seed", value=seed_value, plugin=SeederPlugin)
+
+        if use_fixed_seed is not None:
+            set_scenario_meta(scn, key="use_fixed_seed", value=use_fixed_seed, plugin=SeederPlugin)
+
+        return cast(Type[T], scn)
+
+    return apply_seed
+
+
+def _format_seed_usage_error(seed_value: str) -> str:
+    """
+    Format an error message explaining correct usage of the @seed decorator.
+
+    :param seed_value: The seed value provided to the decorator.
+    :return: A usage error message with examples for both class-based and function-based scenarios.
+    """
+    return linesep.join([
+        "Decorator @seed can be used only with Vedro scenarios:",
+        "",
+        "cls-based:",
+        f"    @seed({seed_value!r})",
+        "    class Scenario(vedro.Scenario):",
+        "        ...",
+        "",
+        "fn-based:",
+        f"    @scenario[seed({seed_value!r})]()",
+        "    def subject():",
+        "        ...",
+    ])

--- a/vedro/plugins/seeder/_seed.py
+++ b/vedro/plugins/seeder/_seed.py
@@ -1,6 +1,6 @@
 from inspect import isclass
 from os import linesep
-from typing import Callable, Optional, Type, TypeVar, cast
+from typing import Callable, Type, TypeVar, cast
 
 from vedro._scenario import Scenario
 from vedro.core import set_scenario_meta
@@ -13,8 +13,7 @@ __all__ = ("seed",)
 T = TypeVar("T", bound=Scenario)
 
 
-def seed(seed_value: str, *,
-         use_fixed_seed: Optional[bool] = None) -> Callable[[Type[T]], Type[T]]:
+def seed(seed_value: str) -> Callable[[Type[T]], Type[T]]:
     """
     Set a custom seed for a Vedro scenario, optionally specifying fixed seed behavior.
 
@@ -28,22 +27,12 @@ def seed(seed_value: str, *,
         class Scenario(vedro.Scenario):
             ...
 
-        @seed("custom-seed-456", use_fixed_seed=True)
-        class Scenario(vedro.Scenario):
-            ...
-
     fn-based:
         @scenario[seed("custom-seed-123")]()
         def subject():
             ...
 
-        @scenario[seed("custom-seed-456", use_fixed_seed=True)]()
-        def subject():
-            ...
-
     :param seed_value: The seed value to use for this scenario.
-    :param use_fixed_seed: Whether to use the same seed for repeated runs of this scenario
-                          within the same test execution. If None, falls back to global setting.
     :return: A decorator that applies the seed configuration to the scenario.
     :raises TypeError: If used on a non-Scenario class.
     """
@@ -59,9 +48,6 @@ def seed(seed_value: str, *,
             raise TypeError(_format_seed_usage_error(seed_value))
 
         set_scenario_meta(scn, key="seed", value=seed_value, plugin=SeederPlugin)
-
-        if use_fixed_seed is not None:
-            set_scenario_meta(scn, key="use_fixed_seed", value=use_fixed_seed, plugin=SeederPlugin)
 
         return cast(Type[T], scn)
 

--- a/vedro/plugins/seeder/_seeder.py
+++ b/vedro/plugins/seeder/_seeder.py
@@ -5,6 +5,8 @@ import uuid
 from hashlib import blake2b
 from typing import Dict, Type, Union, final
 
+from niltype import Nil
+
 from vedro.core import Dispatcher, Plugin, PluginConfig
 from vedro.events import ArgParsedEvent, ArgParseEvent, CleanupEvent, ScenarioRunEvent
 
@@ -104,7 +106,11 @@ class SeederPlugin(Plugin):
         self._history[unique_id] = self._history.get(unique_id, 0) + 1
 
         index = 1 if self._use_fixed_seed else self._history[unique_id]
-        seed = self._create_seed(self._initial_seed, unique_id, index)
+        custom_seed = event.scenario_result.scenario.get_meta("seed", plugin=self)
+        if custom_seed is not Nil:
+            seed = str(custom_seed)
+        else:
+            seed = self._create_seed(self._initial_seed, unique_id, index)
         self._random.set_seed(seed)
 
         if self._show_seeds:

--- a/vedro/plugins/seeder/_seeder.py
+++ b/vedro/plugins/seeder/_seeder.py
@@ -94,9 +94,9 @@ class SeederPlugin(Plugin):
         """
         Handle the event when a scenario starts running, setting a scenario-specific seed.
 
-        Generates a unique seed for the scenario based on the initial seed, scenario ID, and
-        execution index. If configured to show seeds, adds the seed to the scenario's extra
-                         details.
+        Uses a custom seed if one was set via the @seed decorator, otherwise generates a unique
+        seed based on the initial seed, scenario ID, and execution index. If configured to show
+        seeds, adds the seed to the scenario's extra details.
 
         :param event: The ScenarioRunEvent instance containing scenario and result information.
         """


### PR DESCRIPTION
Resolves https://github.com/vedro-universe/vedro/issues/97

Introduces a `@seed` decorator that allows setting custom seed values for individual test scenarios, providing
  fine-grained control over random behavior in tests.