### PR TITLE
Add `vedro config init` command for configuration file management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build:
 .PHONY: test
 test:
 	python3 -m pytest
-	python3 -m vedro tests/
+	python3 -m vedro run tests/
 
 # ------------------------------------------------------------------------------
 # coverage
@@ -161,8 +161,6 @@ bump:
 	@echo
 	@git verify-commit HEAD
 	@git verify-tag `git describe`
-	@echo
-	# git push origin main --tags
 
 # ------------------------------------------------------------------------------
 # publish

--- a/tests/commands/config_command/_helpers.py
+++ b/tests/commands/config_command/_helpers.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Any, Optional, Type
+from unittest.mock import Mock
+
+from rich.console import Console
+
+from vedro import create_tmp_dir, defer
+from vedro.commands import CommandArgumentParser
+from vedro.commands.config_command import ConfigCommand
+from vedro.core import Config
+
+__all__ = ("make_config_command", "make_arg_parser", "make_console", "make_config_class",
+           "create_read_only_dir",)
+
+
+def make_arg_parser(parse_args_result: Optional[Any] = None) -> Mock:
+    arg_parser = Mock(spec_set=CommandArgumentParser)
+
+    if parse_args_result is not None:
+        arg_parser.parse_args.return_value = parse_args_result
+
+    return arg_parser
+
+
+def make_console() -> Mock:
+    return Mock(spec_set=Console)
+
+
+def make_config_class(project_dir_: Path) -> Type[Config]:
+    class CustomConfigProject(Config):
+        project_dir = project_dir_
+
+    return CustomConfigProject
+
+
+def make_config_command(config_class: Type[Config],
+                        arg_parser: CommandArgumentParser,
+                        console: Console) -> ConfigCommand:
+    return ConfigCommand(config_class, arg_parser, console_factory=lambda: console)
+
+
+def create_read_only_dir() -> Path:
+    tmp_dir = create_tmp_dir()
+    tmp_dir.chmod(0o555)
+    defer(tmp_dir.chmod, 0o755)
+    return tmp_dir

--- a/tests/commands/config_command/test_config_command.py
+++ b/tests/commands/config_command/test_config_command.py
@@ -1,0 +1,153 @@
+from os import linesep
+from unittest.mock import Mock, call
+
+from vedro import catched, create_tmp_dir, given, scenario, then, when
+from vedro.commands import Command, CommandArgumentParser
+from vedro.commands.config_command import ConfigCommand
+from vedro.commands.config_command._config_command import DEFAULT_CONFIG_TEMPLATE
+from vedro.core import Config
+
+from ._helpers import (
+    create_read_only_dir,
+    make_arg_parser,
+    make_config_class,
+    make_config_command,
+    make_console,
+)
+
+
+@scenario("create config command")
+def _():
+    with given:
+        config = Config
+        arg_parser = CommandArgumentParser()
+
+    with when:
+        command = ConfigCommand(config, arg_parser)
+
+    with then:
+        assert isinstance(command, Command)
+
+
+@scenario("run config init subcommand")
+async def _():
+    with given:
+        config_class = make_config_class(project_dir_=create_tmp_dir())
+        arg_parser_ = make_arg_parser(parse_args_result=Mock(subparser="init"))
+        console_ = make_console()
+        command = make_config_command(config_class, arg_parser_, console_)
+
+    with when:
+        result = await command.run()
+
+    with then:
+        assert result is None
+
+        help_message = "Initialize a new vedro.cfg.py configuration file"
+        assert arg_parser_.mock_calls == [
+            call.add_subparsers(dest="subparser"),
+            call.add_subparsers().add_parser("init", help=help_message),
+            call.parse_args(),
+        ]
+
+        assert console_.mock_calls == [
+            call.print("✔ Configuration file 'vedro.cfg.py' created successfully", style="green")
+        ]
+
+
+@scenario("run config init when file exists and empty")
+async def _():
+    with given:
+        tmp_dir = create_tmp_dir()
+        config_file = tmp_dir / "vedro.cfg.py"
+        config_file.write_text("")  # empty file
+
+        config_class = make_config_class(project_dir_=tmp_dir)
+        arg_parser_ = make_arg_parser(parse_args_result=Mock(subparser="init"))
+        console_ = make_console()
+        command = make_config_command(config_class, arg_parser_, console_)
+
+    with when:
+        result = await command.run()
+
+    with then:
+        assert result is None
+
+        # Empty file should be overwritten with template
+        assert config_file.exists()
+        assert config_file.read_text() == DEFAULT_CONFIG_TEMPLATE
+
+        assert console_.mock_calls == [
+            call.print("✔ Configuration file 'vedro.cfg.py' created successfully", style="green")
+        ]
+
+
+@scenario("try to run config init when file exists and not empty")
+async def _():
+    with given:
+        tmp_dir = create_tmp_dir()
+        config_file = tmp_dir / "vedro.cfg.py"
+        config_file.write_text(original_content := linesep.join([
+            "import vedro",
+            "class Config(vedro.Config):",
+            "    pass"
+        ]))
+
+        config_class = make_config_class(project_dir_=tmp_dir)
+        arg_parser_ = make_arg_parser(parse_args_result=Mock(subparser="init"))
+        console_ = make_console()
+        command = make_config_command(config_class, arg_parser_, console_)
+
+    with when, catched() as exc_info:
+        await command.run()
+
+    with then:
+        assert exc_info.type == SystemExit
+
+        # File content should remain unchanged
+        assert config_file.read_text() == original_content
+
+        assert console_.mock_calls == [
+            call.print("✗ Configuration file 'vedro.cfg.py' already exists and is not empty",
+                       style="red")
+        ]
+
+
+@scenario("try to run config init when file is not writable")
+async def _():
+    with given:
+        tmp_dir = create_read_only_dir()
+
+        config_class = make_config_class(project_dir_=tmp_dir)
+        arg_parser_ = make_arg_parser(parse_args_result=Mock(subparser="init"))
+        console_ = make_console()
+        command = make_config_command(config_class, arg_parser_, console_)
+
+    with when, catched() as exc_info:
+        await command.run()
+
+    with then:
+        assert exc_info.type == SystemExit
+
+        config_path = tmp_dir / "vedro.cfg.py"
+        assert console_.mock_calls == [
+            call.print(f"✗ Could not write to file '{config_path}'",
+                       style="red"),
+            call.print_exception(),
+        ]
+
+
+@scenario("try to run config without subcommand")
+async def _():
+    with given:
+        config_class = make_config_class(project_dir_=create_tmp_dir())
+        arg_parser_ = make_arg_parser()
+        console_ = make_console()
+        command = make_config_command(config_class, arg_parser_, console_)
+
+    with when:
+        await command.run()
+
+    with then:
+        assert arg_parser_.mock_calls[-1] == call.exit()
+        assert console_.mock_calls == []

--- a/tests/commands/version_command/_helpers.py
+++ b/tests/commands/version_command/_helpers.py
@@ -1,0 +1,31 @@
+from typing import Type
+from unittest.mock import Mock
+
+from rich.console import Console
+
+from vedro.commands import CommandArgumentParser
+from vedro.commands.version_command import VersionCommand
+from vedro.core import Config
+
+__all__ = ("make_version_command", "make_arg_parser", "make_console")
+
+
+def make_arg_parser(parse_args_result: Mock = None) -> Mock:
+    arg_parser_ = Mock(spec_set=CommandArgumentParser)
+
+    if parse_args_result is None:
+        parse_args_result = Mock(no_color=False)
+
+    arg_parser_.parse_args.return_value = Mock(no_color=False)
+
+    return arg_parser_
+
+
+def make_console() -> Mock:
+    return Mock(spec_set=Console)
+
+
+def make_version_command(config_class: Type[Config],
+                         arg_parser_: CommandArgumentParser,
+                         console_: Console) -> VersionCommand:
+    return VersionCommand(config_class, arg_parser_, console_factory=lambda: console_)

--- a/tests/commands/version_command/test_version_command.py
+++ b/tests/commands/version_command/test_version_command.py
@@ -1,27 +1,18 @@
 from unittest.mock import Mock, call
 
-import pytest
-from baby_steps import given, then, when
-from rich.console import Console
 from rich.style import Style
 
 import vedro
+from vedro import given, scenario, then, when
 from vedro.commands import Command, CommandArgumentParser
 from vedro.commands.version_command import VersionCommand
 from vedro.core import Config
 
-
-@pytest.fixture()
-def arg_parser_() -> CommandArgumentParser:
-    return Mock(CommandArgumentParser)
+from ._helpers import make_arg_parser, make_console, make_version_command
 
 
-@pytest.fixture()
-def console_() -> Console:
-    return Mock(Console)
-
-
-def test_inheritance():
+@scenario("create version command")
+def _():
     with given:
         config = Config
         arg_parser = CommandArgumentParser()
@@ -33,19 +24,47 @@ def test_inheritance():
         assert isinstance(command, Command)
 
 
-async def test_run(*, console_, arg_parser_: Mock):
+@scenario("run version command")
+async def _():
     with given:
-        command = VersionCommand(Config, arg_parser_, console_factory=lambda: console_)
+        arg_parser_ = make_arg_parser()
+        console_ = make_console()
+        command = make_version_command(Config, arg_parser_, console_)
 
     with when:
         result = await command.run()
 
     with then:
         assert result is None
+
         assert arg_parser_.mock_calls == [
             call.add_argument("--no-color", action="store_true", help="Disable colored output"),
             call.parse_args(),
         ]
+
+        assert console_.mock_calls == [
+            call.print(f"Vedro {vedro.__version__}", style=Style(color="blue"))
+        ]
+
+
+@scenario("run version command with no color option")
+async def _():
+    with given:
+        arg_parser_ = make_arg_parser(parse_args_result=Mock(no_color=True))
+        console_ = make_console()
+        command = make_version_command(Config, arg_parser_, console_)
+
+    with when:
+        result = await command.run()
+
+    with then:
+        assert result is None
+
+        assert arg_parser_.mock_calls == [
+            call.add_argument("--no-color", action="store_true", help="Disable colored output"),
+            call.parse_args(),
+        ]
+
         assert console_.mock_calls == [
             call.print(f"Vedro {vedro.__version__}", style=Style(color="blue"))
         ]

--- a/vedro/_main.py
+++ b/vedro/_main.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Type, cast
 
 from ._config import Config
 from .commands import CommandArgumentParser
+from .commands.config_command import ConfigCommand
 from .commands.plugin_command import PluginCommand
 from .commands.run_command import RunCommand
 from .commands.version_command import VersionCommand
@@ -59,7 +60,7 @@ async def main(argv: Optional[List[str]] = None) -> None:
 
     arg_parser.add_argument("--version", action="store_true", help="Show vedro version")
 
-    commands = {"run", "version", "plugin"}
+    commands = {"run", "version", "plugin", "config"}
     arg_parser.add_argument("command", nargs="?", help=f"Command to run {{{', '.join(commands)}}}")
     args, unknown_args = arg_parser.parse_known_args(argv)
 
@@ -92,6 +93,10 @@ async def main(argv: Optional[List[str]] = None) -> None:
     elif args.command in ("plugin", "plugins"):
         parser = arg_parser_factory("vedro plugin")
         await PluginCommand(config, parser).run()
+
+    elif args.command == "config":
+        parser = arg_parser_factory("vedro config")
+        await ConfigCommand(config, parser).run()
 
     else:
         arg_parser.print_help()

--- a/vedro/commands/config_command/__init__.py
+++ b/vedro/commands/config_command/__init__.py
@@ -1,0 +1,3 @@
+from ._config_command import ConfigCommand
+
+__all__ = ("ConfigCommand",)

--- a/vedro/commands/config_command/_config_command.py
+++ b/vedro/commands/config_command/_config_command.py
@@ -1,0 +1,128 @@
+import sys
+from typing import Any, Callable, Type
+
+from rich.console import Console
+
+from vedro import Config
+
+from .._cmd_arg_parser import CommandArgumentParser
+from .._command import Command
+
+__all__ = ("ConfigCommand", "DEFAULT_CONFIG_TEMPLATE",)
+
+
+DEFAULT_CONFIG_TEMPLATE = """
+import vedro.plugins.director.rich
+import vedro.plugins.skipper
+from vedro.config import env
+
+class Config(vedro.Config):
+    class Plugins(vedro.Config.Plugins):
+        class RichReporter(vedro.plugins.director.rich.RichReporter):
+            enabled = True
+            show_scenario_spinner = True
+            show_full_diff = False
+
+        class Skipper(vedro.plugins.skipper.Skipper):
+            enabled = True
+            forbid_only = env.bool("CI", default=False)
+""".lstrip()
+
+
+def make_console(**kwargs: Any) -> Console:
+    """
+    Create and configure a Rich Console instance.
+
+    The console is used for outputting text in the terminal.
+
+    :param kwargs: Additional keyword arguments to customize the Console.
+    :return: A `Console` instance with specific configurations.
+    """
+    return Console(highlight=False, force_terminal=True, markup=False, soft_wrap=True,
+                   file=sys.stdout, **kwargs)
+
+
+class ConfigCommand(Command):
+    """
+    Implements the 'config' command for Vedro.
+
+    This command manages Vedro configuration files, providing functionality to:
+    - Initialize new configuration files with sensible defaults
+    - Validate existing configurations (future functionality)
+    """
+
+    def __init__(self, config: Type[Config], arg_parser: CommandArgumentParser, *,
+                 console_factory: Callable[[], Console] = make_console) -> None:
+        """
+        Initialize the ConfigCommand.
+
+        :param config: The configuration class for Vedro.
+        :param arg_parser: The argument parser for parsing command-line arguments.
+        :param console_factory: A callable that returns a `Console` instance for output.
+        """
+        super().__init__(config, arg_parser)
+        self._console = console_factory()
+
+    async def run(self) -> None:
+        """
+        Execute the 'config' command.
+
+        Parses the subcommand and executes the appropriate action:
+        - 'init': Creates a new vedro.cfg.py configuration file
+        - No subcommand: Displays help information
+        """
+        subparsers = self._arg_parser.add_subparsers(dest="subparser")
+
+        subparsers.add_parser("init", help="Initialize a new vedro.cfg.py configuration file")
+
+        args = self._arg_parser.parse_args()
+        if args.subparser == "init":
+            self._init_config()
+        else:
+            self._arg_parser.print_help()
+            self._arg_parser.exit()
+
+    def _init_config(self) -> None:
+        """
+        Initialize a new configuration file in the project directory.
+
+        Creates a vedro.cfg.py file with default configuration settings including:
+        - RichReporter plugin with sensible defaults
+        - Skipper plugin with CI-aware configuration
+
+        The method will:
+        1. Check if a non-empty configuration file already exists
+        2. Create the configuration file with default template
+        3. Display success message with the created file path
+
+        Exits with status code 1 if:
+        - Configuration file already exists with content
+        - Unable to write to the configuration file
+        """
+        config_path = self._config.project_dir / "vedro.cfg.py"
+
+        try:
+            content = config_path.read_text()
+            if content.strip():
+                message = "✗ Configuration file 'vedro.cfg.py' already exists and is not empty"
+                self._console.print(message, style="red")
+                sys.exit(1)
+        except FileNotFoundError:
+            # File doesn't exist, which is fine
+            pass
+
+        try:
+            config_path.write_text(DEFAULT_CONFIG_TEMPLATE)
+        except OSError:
+            message = f"✗ Could not write to file '{config_path}'"
+            self._console.print(message, style="red")
+            self._console.print_exception()
+            sys.exit(1)
+
+        try:
+            rel_path = config_path.relative_to(self._config.project_dir)
+        except ValueError:  # pragma: no cover
+            rel_path = config_path
+
+        message = f"✔ Configuration file '{rel_path}' created successfully"
+        self._console.print(message, style="green")


### PR DESCRIPTION
Adds a new `config` command to Vedro with an `init` subcommand that creates a default `vedro.cfg.py` configuration file in the project directory.